### PR TITLE
Query optimization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,34 @@ dependencies {
 
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.14")
     testImplementation 'io.projectreactor:reactor-core:3.4.12'
+
+    // 9. QueryDSL 적용을 위한 의존성 (SpringBoot3.0 부터는 jakarta 사용해야함)
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+
+jar {
+    enabled = false
 }
 
 tasks.named('test') {
@@ -57,3 +85,4 @@ test {
         exclude("com/gamja/**/Batch**.class")
     }
 }
+

--- a/src/main/generated/com/gamja/trello/entity/QBoard.java
+++ b/src/main/generated/com/gamja/trello/entity/QBoard.java
@@ -1,0 +1,44 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBoard is a Querydsl query type for Board
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBoard extends EntityPathBase<Board> {
+
+    private static final long serialVersionUID = -796360080L;
+
+    public static final QBoard board = new QBoard("board");
+
+    public final SetPath<BoardInvitation, QBoardInvitation> boardInvitations = this.<BoardInvitation, QBoardInvitation>createSet("boardInvitations", BoardInvitation.class, QBoardInvitation.class, PathInits.DIRECT2);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final SetPath<Section, QSection> sections = this.<Section, QSection>createSet("sections", Section.class, QSection.class, PathInits.DIRECT2);
+
+    public final StringPath title = createString("title");
+
+    public QBoard(String variable) {
+        super(Board.class, forVariable(variable));
+    }
+
+    public QBoard(Path<? extends Board> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBoard(PathMetadata metadata) {
+        super(Board.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/gamja/trello/entity/QBoardInvitation.java
+++ b/src/main/generated/com/gamja/trello/entity/QBoardInvitation.java
@@ -1,0 +1,65 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBoardInvitation is a Querydsl query type for BoardInvitation
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBoardInvitation extends EntityPathBase<BoardInvitation> {
+
+    private static final long serialVersionUID = -882013655L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBoardInvitation boardInvitation = new QBoardInvitation("boardInvitation");
+
+    public final QTimestamp _super = new QTimestamp(this);
+
+    public final QBoard board;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final QBoardInvitationId id;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final EnumPath<BoardInvitation.BoardRole> role = createEnum("role", BoardInvitation.BoardRole.class);
+
+    public final QUser user;
+
+    public QBoardInvitation(String variable) {
+        this(BoardInvitation.class, forVariable(variable), INITS);
+    }
+
+    public QBoardInvitation(Path<? extends BoardInvitation> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBoardInvitation(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBoardInvitation(PathMetadata metadata, PathInits inits) {
+        this(BoardInvitation.class, metadata, inits);
+    }
+
+    public QBoardInvitation(Class<? extends BoardInvitation> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new QBoard(forProperty("board")) : null;
+        this.id = inits.isInitialized("id") ? new QBoardInvitationId(forProperty("id"), inits.get("id")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/gamja/trello/entity/QBoardInvitationId.java
+++ b/src/main/generated/com/gamja/trello/entity/QBoardInvitationId.java
@@ -1,0 +1,52 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBoardInvitationId is a Querydsl query type for BoardInvitationId
+ */
+@Generated("com.querydsl.codegen.DefaultEmbeddableSerializer")
+public class QBoardInvitationId extends BeanPath<BoardInvitationId> {
+
+    private static final long serialVersionUID = -1506562780L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBoardInvitationId boardInvitationId = new QBoardInvitationId("boardInvitationId");
+
+    public final QBoard board;
+
+    public final QUser user;
+
+    public QBoardInvitationId(String variable) {
+        this(BoardInvitationId.class, forVariable(variable), INITS);
+    }
+
+    public QBoardInvitationId(Path<? extends BoardInvitationId> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBoardInvitationId(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBoardInvitationId(PathMetadata metadata, PathInits inits) {
+        this(BoardInvitationId.class, metadata, inits);
+    }
+
+    public QBoardInvitationId(Class<? extends BoardInvitationId> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new QBoard(forProperty("board")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/gamja/trello/entity/QCard.java
+++ b/src/main/generated/com/gamja/trello/entity/QCard.java
@@ -1,0 +1,74 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCard is a Querydsl query type for Card
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCard extends EntityPathBase<Card> {
+
+    private static final long serialVersionUID = -2103882170L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCard card = new QCard("card");
+
+    public final QTimestamp _super = new QTimestamp(this);
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final DatePath<java.time.LocalDate> dueDate = createDate("dueDate", java.time.LocalDate.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final QSection section;
+
+    public final NumberPath<Integer> sort = createNumber("sort", Integer.class);
+
+    public final StringPath status = createString("status");
+
+    public final StringPath title = createString("title");
+
+    public final QUser user;
+
+    public final StringPath writer = createString("writer");
+
+    public QCard(String variable) {
+        this(Card.class, forVariable(variable), INITS);
+    }
+
+    public QCard(Path<? extends Card> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCard(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCard(PathMetadata metadata, PathInits inits) {
+        this(Card.class, metadata, inits);
+    }
+
+    public QCard(Class<? extends Card> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.section = inits.isInitialized("section") ? new QSection(forProperty("section"), inits.get("section")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/gamja/trello/entity/QComment.java
+++ b/src/main/generated/com/gamja/trello/entity/QComment.java
@@ -1,0 +1,64 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QComment is a Querydsl query type for Comment
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QComment extends EntityPathBase<Comment> {
+
+    private static final long serialVersionUID = 100583273L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QComment comment = new QComment("comment");
+
+    public final QTimestamp _super = new QTimestamp(this);
+
+    public final QCard card;
+
+    public final StringPath content = createString("content");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final QUser user;
+
+    public QComment(String variable) {
+        this(Comment.class, forVariable(variable), INITS);
+    }
+
+    public QComment(Path<? extends Comment> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QComment(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QComment(PathMetadata metadata, PathInits inits) {
+        this(Comment.class, metadata, inits);
+    }
+
+    public QComment(Class<? extends Comment> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.card = inits.isInitialized("card") ? new QCard(forProperty("card"), inits.get("card")) : null;
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/gamja/trello/entity/QRefreshToken.java
+++ b/src/main/generated/com/gamja/trello/entity/QRefreshToken.java
@@ -1,0 +1,53 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRefreshToken is a Querydsl query type for RefreshToken
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRefreshToken extends EntityPathBase<RefreshToken> {
+
+    private static final long serialVersionUID = 586745108L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRefreshToken refreshToken = new QRefreshToken("refreshToken");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath token = createString("token");
+
+    public final QUser user;
+
+    public QRefreshToken(String variable) {
+        this(RefreshToken.class, forVariable(variable), INITS);
+    }
+
+    public QRefreshToken(Path<? extends RefreshToken> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRefreshToken(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRefreshToken(PathMetadata metadata, PathInits inits) {
+        this(RefreshToken.class, metadata, inits);
+    }
+
+    public QRefreshToken(Class<? extends RefreshToken> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new QUser(forProperty("user"), inits.get("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/gamja/trello/entity/QSection.java
+++ b/src/main/generated/com/gamja/trello/entity/QSection.java
@@ -1,0 +1,65 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QSection is a Querydsl query type for Section
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QSection extends EntityPathBase<Section> {
+
+    private static final long serialVersionUID = 1120425967L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QSection section = new QSection("section");
+
+    public final QTimestamp _super = new QTimestamp(this);
+
+    public final QBoard board;
+
+    public final SetPath<Card, QCard> cards = this.<Card, QCard>createSet("cards", Card.class, QCard.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final NumberPath<Integer> sort = createNumber("sort", Integer.class);
+
+    public final StringPath title = createString("title");
+
+    public QSection(String variable) {
+        this(Section.class, forVariable(variable), INITS);
+    }
+
+    public QSection(Path<? extends Section> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QSection(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QSection(PathMetadata metadata, PathInits inits) {
+        this(Section.class, metadata, inits);
+    }
+
+    public QSection(Class<? extends Section> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.board = inits.isInitialized("board") ? new QBoard(forProperty("board")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/gamja/trello/entity/QTimestamp.java
+++ b/src/main/generated/com/gamja/trello/entity/QTimestamp.java
@@ -1,0 +1,39 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTimestamp is a Querydsl query type for Timestamp
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QTimestamp extends EntityPathBase<Timestamp> {
+
+    private static final long serialVersionUID = -573577312L;
+
+    public static final QTimestamp timestamp = new QTimestamp("timestamp");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = createDateTime("modifiedAt", java.time.LocalDateTime.class);
+
+    public QTimestamp(String variable) {
+        super(Timestamp.class, forVariable(variable));
+    }
+
+    public QTimestamp(Path<? extends Timestamp> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTimestamp(PathMetadata metadata) {
+        super(Timestamp.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/com/gamja/trello/entity/QUser.java
+++ b/src/main/generated/com/gamja/trello/entity/QUser.java
@@ -1,0 +1,71 @@
+package com.gamja.trello.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = -2103329023L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUser user = new QUser("user");
+
+    public final QTimestamp _super = new QTimestamp(this);
+
+    public final SetPath<BoardInvitation, QBoardInvitation> boardInvitations = this.<BoardInvitation, QBoardInvitation>createSet("boardInvitations", BoardInvitation.class, QBoardInvitation.class, PathInits.DIRECT2);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath email = createString("email");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> modifiedAt = _super.modifiedAt;
+
+    public final StringPath nickname = createString("nickname");
+
+    public final StringPath password = createString("password");
+
+    public final EnumPath<User.Role> role = createEnum("role", User.Role.class);
+
+    public final QRefreshToken token;
+
+    public final DateTimePath<java.time.LocalDateTime> withdrawAt = createDateTime("withdrawAt", java.time.LocalDateTime.class);
+
+    public QUser(String variable) {
+        this(User.class, forVariable(variable), INITS);
+    }
+
+    public QUser(Path<? extends User> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUser(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUser(PathMetadata metadata, PathInits inits) {
+        this(User.class, metadata, inits);
+    }
+
+    public QUser(Class<? extends User> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.token = inits.isInitialized("token") ? new QRefreshToken(forProperty("token"), inits.get("token")) : null;
+    }
+
+}
+

--- a/src/main/java/com/gamja/trello/config/JPAConfiguration.java
+++ b/src/main/java/com/gamja/trello/config/JPAConfiguration.java
@@ -1,0 +1,19 @@
+package com.gamja.trello.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JPAConfiguration {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/gamja/trello/dto/BoardDto.java
+++ b/src/main/java/com/gamja/trello/dto/BoardDto.java
@@ -18,13 +18,13 @@ public class BoardDto {
     private Long id;
     private String title;
     private Page<SectionDto> sections;
+    private PageDto cardPage;
 
     public BoardDto(Board board, Page<SectionDto> sections, Page<CardDto> cards) {
         this.id = board.getId();
         this.title = board.getTitle();
-
-        // sections 리스트 초기화
         this.sections = sections;
+        this.cardPage = new PageDto(cards.getTotalPages(), cards.hasNext(), cards.isLast());
 
         // 각 카드를 해당 섹션에 추가
         for (CardDto card : cards) {
@@ -48,10 +48,6 @@ public class BoardDto {
             this.title = title;
         }
 
-        public Long getId() {
-            return id;
-        }
-
         public void addCard(CardDto card) {
             this.cards.add(card);
         }
@@ -70,18 +66,13 @@ public class BoardDto {
         private String writer;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
+    }
 
-        public CardDto(Card card) {
-            this.id = card.getId();
-            this.sectionId = card.getSection().getId();
-            this.title = card.getTitle();
-            this.content = card.getContent();
-            this.sort = card.getSort();
-            this.dueDate = card.getDueDate();
-            this.status = card.getStatus();
-            this.writer = card.getWriter();
-            this.createdAt = card.getCreatedAt();
-            this.modifiedAt = card.getModifiedAt();
-        }
+    @Getter
+    @AllArgsConstructor
+    public static class PageDto {
+        private int totalPages;
+        private boolean hasNext;
+        private boolean isLast;
     }
 }

--- a/src/main/java/com/gamja/trello/dto/BoardDto.java
+++ b/src/main/java/com/gamja/trello/dto/BoardDto.java
@@ -1,0 +1,87 @@
+package com.gamja.trello.dto;
+
+import com.gamja.trello.entity.Board;
+import com.gamja.trello.entity.Card;
+import com.gamja.trello.entity.Section;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class BoardDto {
+    private Long id;
+    private String title;
+    private Page<SectionDto> sections;
+
+    public BoardDto(Board board, Page<SectionDto> sections, Page<CardDto> cards) {
+        this.id = board.getId();
+        this.title = board.getTitle();
+
+        // sections 리스트 초기화
+        this.sections = sections;
+
+        // 각 카드를 해당 섹션에 추가
+        for (CardDto card : cards) {
+            for (SectionDto section : this.sections.getContent()) {
+                if (section.getId().equals(card.getSectionId())) {
+                    section.addCard((card));
+                }
+            }
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class SectionDto {
+        private Long id;
+        private String title;
+        private List<CardDto> cards = new ArrayList<>();
+
+        public SectionDto(Long id, String title) {
+            this.id = id;
+            this.title = title;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public void addCard(CardDto card) {
+            this.cards.add(card);
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class CardDto {
+        private Long id;
+        private Long sectionId;
+        private String title;
+        private String content;
+        private int sort;
+        private LocalDate dueDate;
+        private String status;
+        private String writer;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+
+        public CardDto(Card card) {
+            this.id = card.getId();
+            this.sectionId = card.getSection().getId();
+            this.title = card.getTitle();
+            this.content = card.getContent();
+            this.sort = card.getSort();
+            this.dueDate = card.getDueDate();
+            this.status = card.getStatus();
+            this.writer = card.getWriter();
+            this.createdAt = card.getCreatedAt();
+            this.modifiedAt = card.getModifiedAt();
+        }
+    }
+}

--- a/src/main/java/com/gamja/trello/dto/response/BoardReadResponseDto.java
+++ b/src/main/java/com/gamja/trello/dto/response/BoardReadResponseDto.java
@@ -1,0 +1,25 @@
+package com.gamja.trello.dto.response;
+
+import com.gamja.trello.entity.Board;
+import com.gamja.trello.entity.Card;
+import com.gamja.trello.entity.Section;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class BoardReadResponseDto {
+    private Long boardId;
+    private String title;
+
+    private Page<Section> sections;
+    private Page<Card> cards;
+
+    public BoardReadResponseDto(Board board, Page<Section> sections, Page<Card> cards) {
+        this.boardId = board.getId();
+        this.title = board.getTitle();
+        this.sections = sections;
+        this.cards = cards;
+    }
+}

--- a/src/main/java/com/gamja/trello/dto/response/MoveSectionResponseDto.java
+++ b/src/main/java/com/gamja/trello/dto/response/MoveSectionResponseDto.java
@@ -4,12 +4,13 @@ import com.gamja.trello.entity.Section;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Set;
 
 @Getter
 public class MoveSectionResponseDto {
     List<SectionResponseDto> sections;
 
-    public MoveSectionResponseDto(List<Section> sections) {
+    public MoveSectionResponseDto(Set<Section> sections) {
         this.sections = sections.stream().map(SectionResponseDto::new).toList();
     }
 }

--- a/src/main/java/com/gamja/trello/entity/Board.java
+++ b/src/main/java/com/gamja/trello/entity/Board.java
@@ -25,7 +25,8 @@ public class Board {
 
     @OrderBy("sort asc")
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Section> sections = new ArrayList<>();
+//    private List<Section> sections = new ArrayList<>();
+    private Set<Section> sections = new HashSet<>();
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<BoardInvitation> boardInvitations = new HashSet<>();

--- a/src/main/java/com/gamja/trello/entity/Section.java
+++ b/src/main/java/com/gamja/trello/entity/Section.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -30,7 +32,8 @@ public class Section extends Timestamp {
 
 	@OrderBy("sort asc")
 	@OneToMany(mappedBy = "section", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Card> cards = new ArrayList<>();
+	private Set<Card> cards = new HashSet<>();
+//	private List<Card> cards = new ArrayList<>();
 
 	public void addCardList(Card card) {
 		this.cards.add(card);

--- a/src/main/java/com/gamja/trello/repository/BatchRepository.java
+++ b/src/main/java/com/gamja/trello/repository/BatchRepository.java
@@ -77,7 +77,7 @@ public class BatchRepository {
                         ps.setInt(4, 0);
                         ps.setInt(5, 0);
                         ps.setString(6, "test1");
-                        ps.setLong(7, 1);
+                        ps.setLong(7, i+1);   // section_id
                         ps.setLong(8, 1);
                         ps.setString(9, "2024-07-13");
                     }

--- a/src/main/java/com/gamja/trello/repository/BoardCustomRepository.java
+++ b/src/main/java/com/gamja/trello/repository/BoardCustomRepository.java
@@ -1,0 +1,14 @@
+package com.gamja.trello.repository;
+
+import com.gamja.trello.dto.BoardDto;
+import com.gamja.trello.dto.response.BoardReadResponseDto;
+import com.gamja.trello.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface BoardCustomRepository {
+    Page<Board> getFetchJoinBoard(Long id, int page, int size);
+    BoardDto getFetchJoinBoard(Long id, Pageable pageable);
+}

--- a/src/main/java/com/gamja/trello/repository/BoardRepository.java
+++ b/src/main/java/com/gamja/trello/repository/BoardRepository.java
@@ -4,4 +4,24 @@ import com.gamja.trello.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
+//    @Query(value = "select b " +
+//            "from Board b " +
+//            "       left join fetch b.sections s " +
+//            "       left join fetch s.cards c " +
+//            "where b.id= :id " +
+//            "order by s.sort ")
+//    Optional<Board> findBoardAllById(@Param("id") Long id, Pageable pageable);
+
+//    @Query(value = "select " +
+//            "    b.id, b.title, " +
+//            "    s.id, s.title, s.board_id, " +
+//            "    c.id, c.section_id, c.title, c.content, c.sort, " +
+//            "    c.due_date, c.status, c.writer, c.created_at, c.modified_at " +
+//            "from board b " +
+//            "         left join section s on b.id = s.board_id " +
+//            "         left join card c on c.section_id = s.id " +
+//            "where b.id = 1 " +
+//            "order by sort" +
+//            "limit 100", nativeQuery = true)
+//    Optional<List<BoardDetailsDto>> findBoardAllByBoardId(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/gamja/trello/repository/impl/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/gamja/trello/repository/impl/BoardCustomRepositoryImpl.java
@@ -1,0 +1,152 @@
+package com.gamja.trello.repository.impl;
+
+import com.gamja.trello.dto.BoardDto;
+import com.gamja.trello.dto.response.BoardReadResponseDto;
+import com.gamja.trello.entity.*;
+import com.gamja.trello.repository.BoardCustomRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class BoardCustomRepositoryImpl implements BoardCustomRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    /**
+     * board 조회 시 fetch join을 활용하여 페이지네이션
+     * offset을 사용한 페이지네이션 - 실패 => fetch join에는 limit 적용이 안된다.
+     */
+    public Page<Board> getFetchJoinBoard(Long id, int page, int size) {
+        QBoard board = QBoard.board;
+        QSection section = QSection.section;
+        QCard card = QCard.card;
+
+        // count
+        JPAQuery<Long> queryCount = jpaQueryFactory
+                .select(board.count())
+                .from(board)
+                .where(
+                        board.id.eq(id)
+                );
+
+        // fetch join
+        List<Board> boards = jpaQueryFactory
+                .selectFrom(board)
+                .leftJoin(board.sections, section).fetchJoin()
+                .leftJoin(section.cards, card).fetchJoin()
+                .where(board.id.eq(id))
+                .offset((page - 1) * size) // 페이지네이션을 위한 offset
+                .limit(size) // 페이지네이션을 위한 limit
+                .distinct() // 중복 제거
+                .fetch();
+
+        Pageable pageable = PageRequest.of(page-1, size);
+
+        return new PageImpl<>(boards, pageable, (Long) queryCount.fetchOne());
+    }
+
+    /**
+     * board 조회 시 fetch join을 활용하여 페이지네이션
+     * offset을 사용한 페이지네이션 - 실패 => fetch join에는 limit 적용이 안된다.
+     */
+    public BoardDto getFetchJoinBoard(Long id, Pageable pageable) {
+        QBoard qboard = QBoard.board;
+        QSection qsection = QSection.section;
+        QCard qcard = QCard.card;
+
+        // qboard 조회
+        Board board = jpaQueryFactory
+                .selectFrom(qboard)
+                .where(qboard.id.eq(id))
+                .fetchOne();
+
+        Page<BoardDto.SectionDto> sections = selectSections(board.getId(), qsection, pageable);
+        List<Long> sectionIds = sections.getContent().stream().map(BoardDto.SectionDto::getId).toList();
+        Page<BoardDto.CardDto> cards = selectCards(sectionIds, qcard, pageable);
+
+        return new BoardDto(board, sections, cards);
+    }
+
+    // section count 조회
+    private JPAQuery<Long> getSectionQueryCount(Long boardId, QSection section) {
+        return jpaQueryFactory
+                .select(section.count())
+                .from(section)
+                .where(
+                        section.board.id.eq(boardId)
+                );
+    }
+
+    // card count 조회
+    private JPAQuery<Long> getCardQueryCount(List<Long> sectionIds, QCard card) {
+        return jpaQueryFactory
+                .select(card.count())
+                .from(card)
+                .where(
+                        card.section.id.in(sectionIds)
+                );
+    }
+
+    // section select 조회
+    private Page<BoardDto.SectionDto> selectSections(Long boardId, QSection section, Pageable pageable) {
+//        List<Section> sections = jpaQueryFactory.selectFrom(section)
+//                .where(section.board.id.eq(boardId))
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .fetch();
+
+        List<BoardDto.SectionDto> sections = jpaQueryFactory.select(
+                        Projections.constructor(BoardDto.SectionDto.class,
+                                section.id,
+                                section.title
+                                )
+                )
+                .from(section)
+                .where(section.board.id.eq(boardId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return PageableExecutionUtils.getPage(sections, pageable, () -> getSectionQueryCount(boardId, section).fetchFirst());
+    }
+
+    // section select 조회
+    private Page<BoardDto.CardDto> selectCards(List<Long> sectionIds, QCard card, Pageable pageable) {
+//        List<Card> cards = jpaQueryFactory.selectFrom(card)
+//                .where(card.section.id.in(sectionIds))
+//                .offset(pageable.getOffset())
+//                .limit(pageable.getPageSize())
+//                .fetch();
+
+        List<BoardDto.CardDto> cards = jpaQueryFactory.select(
+                Projections.constructor(BoardDto.CardDto.class,
+                        card.id,
+                        card.section.id,
+                        card.title,
+                        card.content,
+                        card.sort,
+                        card.dueDate,
+                        card.status,
+                        card.writer,
+                        card.createdAt,
+                        card.modifiedAt
+                )
+                )
+                .from(card)
+                .where(card.section.id.in(sectionIds))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+        return PageableExecutionUtils.getPage(cards, pageable, () -> getCardQueryCount(sectionIds, card).fetchFirst());
+    }
+}

--- a/src/main/java/com/gamja/trello/service/BoardService.java
+++ b/src/main/java/com/gamja/trello/service/BoardService.java
@@ -57,7 +57,13 @@ public class BoardService {
     @Transactional
     public BoardDetailResponseDto getBoard(Long boardId) {
 
+        int size = 100;
+//        Pageable pageable = PageRequest.of(0, size);
         Board board = findBoard(boardId);
+
+//        Board board = boardRepository.findBoardAllById(boardId, pageable).orElseThrow(
+//                () -> new CustomException(ErrorCode.BOARD_NOT_FOUND)
+//        );
 
         return BoardDetailResponseDto.builder()
                 .board(board)
@@ -154,6 +160,10 @@ public class BoardService {
     }
 
     public Board findBoard(Long id) {
+
+//        return boardRepository.findBoardAllById(id).orElseThrow(
+//                () -> new CustomException(ErrorCode.BOARD_NOT_FOUND)
+//        );
 
         return boardRepository.findById(id).orElseThrow(
                 () -> new CustomException(ErrorCode.BOARD_NOT_FOUND)

--- a/src/main/java/com/gamja/trello/service/SectionService.java
+++ b/src/main/java/com/gamja/trello/service/SectionService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -51,7 +52,7 @@ public class SectionService {
 
 	@Transactional
 	public MoveSectionResponseDto moveSection(Long boardId, MoveSectionRequestDto requestDto) {
-		List<Section> sections = boardService.findBoard(boardId).getSections();
+		Set<Section> sections = boardService.findBoard(boardId).getSections();
 
 		Map<Long, Integer> reqSectionMap = requestDto.getSections().stream()
 				.collect(Collectors.toMap(MoveSectionRequestDto.section::getId, MoveSectionRequestDto.section::getSort));

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,7 @@ spring.jpa.open-in-view=false
 jwt.secret-key=${JWT_SECRET}
 jwt.time.access=${JWT_ACCESS_TIME}
 jwt.time.refresh=${JWT_REFRESH_TIME}
+
+
+logging.level.org.hibernate.type=trace
+#spring.jpa.properties.hibernate.default_batch_fetch_size=1000

--- a/src/test/java/com/gamja/trello/config/TestRepositoryConfig.java
+++ b/src/test/java/com/gamja/trello/config/TestRepositoryConfig.java
@@ -1,0 +1,26 @@
+package com.gamja.trello.config;
+
+import com.gamja.trello.repository.BoardCustomRepository;
+import com.gamja.trello.repository.impl.BoardCustomRepositoryImpl;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestRepositoryConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+    @Bean
+    public BoardCustomRepository boardCustomRepository() {
+        return new BoardCustomRepositoryImpl(jpaQueryFactory());
+    }
+}

--- a/src/test/java/com/gamja/trello/repository/BatchRepositoryTest.java
+++ b/src/test/java/com/gamja/trello/repository/BatchRepositoryTest.java
@@ -96,7 +96,7 @@ class BatchRepositoryTest {
             System.out.println("현재 id: " + tableId);
 
             int count = 10; // jdbc 기본 커넥션이 10
-            int size = 1000;
+            int size = 100;
 
             Flux.range(0, count)
                     .parallel()

--- a/src/test/java/com/gamja/trello/repository/impl/BoardCustomRepositoryImplTest.java
+++ b/src/test/java/com/gamja/trello/repository/impl/BoardCustomRepositoryImplTest.java
@@ -46,11 +46,7 @@ class BoardCustomRepositoryImplTest {
 
         System.out.println(board.getContent().get(0).getId());
         // then
-//        board.get(0).getSections()
-//                .stream()
-//                .iterator()
-//                .next()
-//                .getCards().forEach(card -> System.out.println(card.getId()));
+        // fetch join은 limit 적용이 되지 않는다. -> oom 발생
     }
 
     @DisplayName("쿼리 분할")
@@ -58,7 +54,7 @@ class BoardCustomRepositoryImplTest {
     void test2() {
         // given
         Long boardId = 1L;
-        int page = 2;
+        int page = 1;
         int size = 10;
 
         Pageable pageable = PageRequest.of(page-1, size);
@@ -68,22 +64,5 @@ class BoardCustomRepositoryImplTest {
 
         // then
         System.out.println(board.getId());
-
-
-        /*
-        page => section, card 2
-        id 1 section => card 50만건
-        => id 11 ~ card X
-        =>
-
-        page를 따로 가져가야하는데 boardApi, => page? => 프론트
-        => api 를 나눈다? =>
-        [board] => count
-        section => page
-        card => page
-
-        검증? sectionId
-
-         */
     }
 }

--- a/src/test/java/com/gamja/trello/repository/impl/BoardCustomRepositoryImplTest.java
+++ b/src/test/java/com/gamja/trello/repository/impl/BoardCustomRepositoryImplTest.java
@@ -1,0 +1,89 @@
+package com.gamja.trello.repository.impl;
+
+import com.gamja.trello.config.TestRepositoryConfig;
+import com.gamja.trello.dto.BoardDto;
+import com.gamja.trello.dto.response.BoardReadResponseDto;
+import com.gamja.trello.entity.Board;
+import com.gamja.trello.repository.BoardRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Import(TestRepositoryConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class BoardCustomRepositoryImplTest {
+    @Autowired
+    BoardCustomRepositoryImpl boardCustomRepository;
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @DisplayName("board에 있는 데이터를 페이지네이션 후 fetch join하여 가져온다.")
+    @Test
+    void test1() {
+        // given
+        Long boardId = 1L;
+        int page = 1;
+        int size = 1;
+
+        // when
+//        List<Board> board = boardCustomRepository.getFetchJoinBoard(boardId, page, size);
+        Page<Board> board = boardCustomRepository.getFetchJoinBoard(boardId, page, size);
+
+        System.out.println(board.getContent().get(0).getId());
+        // then
+//        board.get(0).getSections()
+//                .stream()
+//                .iterator()
+//                .next()
+//                .getCards().forEach(card -> System.out.println(card.getId()));
+    }
+
+    @DisplayName("쿼리 분할")
+    @Test
+    void test2() {
+        // given
+        Long boardId = 1L;
+        int page = 2;
+        int size = 10;
+
+        Pageable pageable = PageRequest.of(page-1, size);
+
+        // when
+        BoardDto board = boardCustomRepository.getFetchJoinBoard(boardId, pageable);
+
+        // then
+        System.out.println(board.getId());
+
+
+        /*
+        page => section, card 2
+        id 1 section => card 50만건
+        => id 11 ~ card X
+        =>
+
+        page를 따로 가져가야하는데 boardApi, => page? => 프론트
+        => api 를 나눈다? =>
+        [board] => count
+        section => page
+        card => page
+
+        검증? sectionId
+
+         */
+    }
+}


### PR DESCRIPTION
#20 

- 각 조회 쿼리를 분리하여 조회
- ToMany 관계에 있는 테이블은 페이징을 적용하여 조회하도록 함
- 처음 조회 시 board 조회, 다음 페이지 필요 시에는 각 section, card 조회 API를 사용